### PR TITLE
Open links in a new tab + Add Invictus Brewery in Blaine

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -31,7 +31,7 @@ var tapLayer = new L.GeoJSON.AJAX("js/things.geojson",{
 		    	
 				 var html = '';
                if (feature.properties.web) {
-                      html += '<h3><a href="'+ feature.properties.web + '">' + feature.properties.title + '</a></h3>';
+                      html += '<span style="font-size:1.5em;"><a href="'+ feature.properties.web + '" target="_blank">' + feature.properties.title + '</a>, </span><small> opens in a new tab</small>';
                                            } 
                else {
                       html += '<h3>' + feature.properties.title + '</h3>';

--- a/js/things.geojson
+++ b/js/things.geojson
@@ -1799,6 +1799,22 @@
 {
   "type": "Feature",
   "properties": {
+    "title": "Invictus Brewing Company",
+    "address": "2025 105th Ave NE, Blaine, MN 55449",
+    "web": "http://invictusbrewingco.com",
+    "status": "open"
+  },
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -93.219518,
+      45.161803
+    ]
+  }
+},
+{
+  "type": "Feature",
+  "properties": {
     "title": "Angry Minnow Brewing Company",
     "address": "10440 Florida Ave., Hayward, WI 54843",
     "web": "http://angryminnow.com",


### PR DESCRIPTION
This PR includes two enhancements:

**1. Open brewery links in a new tab**, for example:

<img width="283" alt="Screen shot of 10k brewing in Anoka with updated popup" src="https://user-images.githubusercontent.com/5023024/67148875-299b2780-f26a-11e9-8479-cab4e9251df7.png">

**2. Added Invictus Brewery in Blaine (Minnesota)**  